### PR TITLE
0.0.1 update

### DIFF
--- a/app/forked/changelog.md
+++ b/app/forked/changelog.md
@@ -1,0 +1,15 @@
+Current Version
+
+Version 0.0.1
+* Fixed bug: Changing the size_enum caused interpolated text to appear in the wrong x location and line lengths were miscalculated.
+* Fixed bug: When displaying the story title in place of a missing heading, the prefix # was displayed.
+* Fixed bug: Comment markers at line character zero were ignored if the line contained extra comment markers later on.
+* Reenabled feature "preserved line" (effectivle pre-formatted) allows a line to skip formatting and be presented as-is. Marker: line starts with `$$`.
+* Clean-up in parse.rb to use methods to create hashes so they can be consistently applied from anywhere.
+* Fixed bug: If there are two interpolated texts, they will now be displayed as two paragraphs if there is a blank line between them.
+* Fixed bug (possibly): trigger action code starting with `#` tries to navigate instead of executing code. This is fixed with a kludge so Forked can tell the difference at runtime. It seems to work.
+
+Previous versions:
+
+Version 0.0.0
+* Initial version

--- a/app/forked/display.rb
+++ b/app/forked/display.rb
@@ -108,13 +108,14 @@ module Forked
         when :paragraph
           zero_height = true # paragraph could have no text, in which case it will have no height
           x_pos = 0
+
           item.atoms.each do |atom|
             next if atom[:text].empty?
 
             zero_height = false
             # defaults
             paragraph.size_px = args.gtk.calcstringbox('X', paragraph.size_enum, paragraph.font)[1]
-
+            
             # font style can change
             font_style = get_font_style(atom.styles)
 
@@ -124,10 +125,8 @@ module Forked
 
             until words.empty?
               word = words[0]
-
               new_frag = line_frag + word
-              new_x_pos = x_pos + gtk.calcstringbox(new_frag, font_style.enum, font_style.font)[0]
-
+              new_x_pos = x_pos + gtk.calcstringbox(new_frag, font_style.size_enum, font_style.font)[0]
               if new_x_pos > display.w
                 loc = { x: x_pos + display.margin_left, y: y_pos }
                 lab = loc.merge(make_paragraph_label(line_frag, font_style))

--- a/app/forked/forked.rb
+++ b/app/forked/forked.rb
@@ -29,6 +29,10 @@ module Forked
 
     def follow(args, option = nil)
       if option&.action && !option.action.start_with?("#")
+        # @@@@ was added to code to prevent it being confused with a #navigational_action.
+        # The @@@@ part needs to be removed now.
+        # Seems to work but I don't trust it
+        option.action.delete_prefix!('@@@@')
         evaluate(args, option.action.to_s)
         return
       end

--- a/app/forked/parse.rb
+++ b/app/forked/parse.rb
@@ -5,8 +5,8 @@ module Forked
 
     class << self
       def parse(story_file)
-        raise 'The story file is missing.' if story_file.nil?
-        raise 'The story file is empty.' if story_file.empty?
+        raise 'FORKED: The story file is missing.' if story_file.nil?
+        raise 'FORKED: The story file is empty.' if story_file.empty?
 
         # Empty story
         story = {
@@ -574,7 +574,6 @@ Please add a title to the top of the Story File. Example:
         return unless context_safe?(context, prohibited_contexts, mandatory_contexts)
 
         context.delete(:heading)
-        # raise "CONTEXT ERROR. Context should be empty but context is #{context}" unless context.empty?
 
         line.strip!
         line.delete_prefix!('##').strip!
@@ -591,7 +590,7 @@ Please add a title to the top of the Story File. Example:
               raise "Forked: Expected heading and/or ID on line #{line_no + 1}."
             end
 
-            heading = story.title if heading.empty?
+            heading = story.title.delete_prefix!("#").strip! if heading.empty?
 
             story[:chunks] << {
               id: chunk_id,

--- a/app/forked/parse.rb
+++ b/app/forked/parse.rb
@@ -581,6 +581,11 @@ Please add a title to the top of the Story File. Example:
 
         # if context is open, add line to trigger action (return)
         elsif context.include?(:trigger_action)
+          if story[:chunks][-1][:content][-1].action.size.zero?
+            # a kludge that identifies a Ruby trigger action from a normal action 
+            # so actions that begin with '#' are not mistaken for navigational actions
+            line = '@@@@' + line
+          end
           story[:chunks][-1][:content][-1].action += line
           return true
         end

--- a/app/forked/parse.rb
+++ b/app/forked/parse.rb
@@ -389,19 +389,30 @@ Please add a heading line after the title and before any other content. Example:
         mandatory_contexts = []
         return unless context_safe?(context, prohibited_contexts, mandatory_contexts)
 
+        # DETECT OPENING CONDITION BLOCK
         # opening condition block context and condition code context
         if line.strip.end_with?('<%```')
+          # open condition block context
           context << :condition_block
+          # open condition code block context
           context << :condition_code_block
+          # add a new condition to the chunk
           story[:chunks][-1][:conditions] << ''
+          # stop processing this line (ignore any following text)
           return true
         end
 
+        # DETECT CLOSING CONDITION BLOCK & CONDITION CODE BLOCK
+        # (IF ON SAME LINE - INDICATES STRING INTERPOLATION)
         # closing both condition code context and condition block context
         if line.strip.start_with?('```%>')
+          # close conditon block and condition code block contexts
           context.delete(:condition_block)
           context.delete(:condition_code_block)
-          if story[:chunks][-1][:content][-1].type == :paragraph
+          # if the last element is a paragraph and
+          # if the paragraph context is open, add to it
+          
+          if story[:chunks][-1][:content][-1].type == :paragraph && context.include?(:paragraph)
             atm = make_atom_hash
             atm[:condition] = story[:chunks][-1][:conditions][-1] 
             story[:chunks][-1][:content][-1][:atoms] << atm

--- a/app/forked/parse.rb
+++ b/app/forked/parse.rb
@@ -153,15 +153,11 @@ Please add a heading line after the title and before any other content. Example:
 
         line.delete_prefix!('$$')
 
-        story[:chunks][-1][:content] << {
-          type: :paragraph,
-          atoms: [
-            {
-              text: line,
-              styles: []
-            }
-          ]
-        }
+        para = make_paragraph_hash
+        atm = make_atom_hash
+        atm[:text] = line
+        para[:atoms] << atm
+        story[:chunks][-1][:content] << para
 
         true
       end


### PR DESCRIPTION
Version 0.0.1
* Fixed bug: Changing the size_enum caused interpolated text to appear in the wrong x location and line lengths were miscalculated.
* Fixed bug: When displaying the story title in place of a missing heading, the prefix # was displayed.
* Fixed bug: Comment markers at line character zero were ignored if the line contained extra comment markers later on.
* Reenabled feature "preserved line" (effectivle pre-formatted) allows a line to skip formatting and be presented as-is. Marker: line starts with `$$`.
* Clean-up in parse.rb to use methods to create hashes so they can be consistently applied from anywhere.
* Fixed bug: If there are two interpolated texts, they will now be displayed as two paragraphs if there is a blank line between them.
* Fixed bug (possibly): trigger action code starting with `#` tries to navigate instead of executing code. This is fixed with a kludge so Forked can tell the difference at runtime. It seems to work.