### PR TITLE
Add a link to the README to the sample file

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ What it lets you do:
 ## Getting started
 Download or clone the project and run it in DragonRuby.
 
-The default project is the user manual.
+The default project is the user manual. [Click here to see how it's built!](https://github.com/oeloeloel/forked/blob/main/app/story.md)
 
 ## Quick Reference
 


### PR DESCRIPTION
Tiny tweak but when I was reading the README I was hoping for a sample file I could see (even a tiny one); this isn't quite as good as embedding an actual tiny sample, but having this link here means a reader CAN easily jump to the file and see what it looks like if their goal is to understand what a full story file might look like (and as a bonus, shouldn't require README changes if the file needs to change a lot...unless the location moves!).